### PR TITLE
Update config.js.j2: remove and update variables based on 2024.12.0

### DIFF
--- a/templates/config.js.j2
+++ b/templates/config.js.j2
@@ -1,11 +1,9 @@
 {#
 SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 XWiki CryptPad Team <contact@cryptpad.org> and contributors
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
-
-/* globals module */
-
 
 module.exports = {
 /*  CryptPad is designed to serve its content over two domains.
@@ -40,7 +38,7 @@ module.exports = {
 /*  httpSafeOrigin is the URL that is used for the 'sandbox' described above.
  *  If you're testing or developing with CryptPad on your local machine then
  *  it is appropriate to leave this blank. The default behaviour is to serve
- *  the main domain over port 3000 and to serve the content over port 3001.
+ *  the main domain over port 3000 and to serve the sandbox content over port 3001.
  *
  *  This is not appropriate in a production environment where invasive networks
  *  may filter traffic going over abnormal ports.
@@ -51,14 +49,17 @@ module.exports = {
  *  This value corresponds to the $sandbox_domain variable
  *  in the example nginx file.
  *
+ *  Note that in order for the sandboxing system to be effective
+ *  httpSafeOrigin must be different from httpUnsafeOrigin.
+ *
  *  CUSTOMIZE AND UNCOMMENT THIS FOR PRODUCTION INSTALLATIONS.
  */
     httpSafeOrigin: "https://{{ cryptpad_sandbox_domain }}",
 
 /*  httpAddress specifies the address on which the nodejs server
- *  should be accessible. By default it will listen on 127.0.0.1
- *  (IPv4 localhost on most systems). If you want it to listen on
- *  all addresses, including IPv6, set this to '::'.
+ *  should be accessible. By default it will listen on localhost
+ *  (IPv4 & IPv6 if enabled). If you want it to listen on
+ *  a specific address, specify it here. e.g '192.168.0.1'
  *
  */
     httpAddress: '::',
@@ -71,12 +72,26 @@ module.exports = {
  */
     httpPort: {{ cryptpad_main_container_port }},
 
-/*  httpSafePort allows you to specify an alternative port from which
- *  the node process should serve sandboxed assets. The default value is
- *  that of your httpPort + 1. You probably don't need to change this.
+/*  httpSafePort purpose is to emulate another origin for the sandbox when
+ *  you don't have two domains at hand (i.e. when httpSafeOrigin not defined).
+ *  It is meant to be used only in case where you are working on a local
+ *  development instance. The default value is your httpPort + 1.
  *
  */
     httpSafePort: {{ cryptpad_sandbox_container_port }},
+
+/*  Websockets need to be exposed on a separate port from the rest of
+ *  the platform's HTTP traffic. Port 3003 is used by default.
+ *  You can change this to a different port if it is in use by a
+ *  different service, but under most circumstances you can leave this
+ *  commented and it will work.
+ *
+ *  In production environments, your reverse proxy (usually NGINX)
+ *  will need to forward websocket traffic (/cryptpad_websocket)
+ *  to this port.
+ *
+ */
+    // websocketPort: 3003,
 
 /*  CryptPad will launch a child process for every core available
  *  in order to perform CPU-intensive tasks in parallel.
@@ -85,6 +100,43 @@ module.exports = {
  *  If so, set 'maxWorkers' to a positive integer.
  */
     maxWorkers: 4,
+
+    /* =====================
+     *       Sessions
+     * ===================== */
+
+    /*  Accounts can be protected with an OTP (One Time Password) system
+     *  to add a second authentication layer. Such accounts use a session
+     *  with a given lifetime after which they are logged out and need
+     *  to be re-authenticated. You can configure the lifetime of these
+     *  sessions here.
+     *
+     *  defaults to 7 days
+     */
+    //otpSessionExpiration: 7*24, // hours
+
+    /*  Registered users can be forced to protect their account
+     *  with a Multi-factor Authentication (MFA) tool like a TOTP
+     *  authenticator application.
+     *
+     *  defaults to false
+     */
+    //enforceMFA: false,
+
+    /* =====================
+     *       Privacy
+     * ===================== */
+
+    /*  Depending on where your instance is hosted, you may be required to log IP
+     *  addresses of the users who make a change to a document. This setting allows you
+     *  to do so. You can configure the logging system below in this config file.
+     *  Setting this value to true will include a log for each websocket connection
+     *  including this connection's unique ID, the user public key and the IP.
+     *  NOTE: this option requires a log level of "info" or below.
+     *
+     *  defaults to false
+     */
+    //logIP: false,
 
     /* =====================
      *         Admin
@@ -96,61 +148,15 @@ module.exports = {
      *  To give access to the admin panel to a user account, just add their public signing
      *  key, which can be found on the settings page for registered users.
      *  Entries should be strings separated by a comma.
+     *  adminKeys: [
+     *      "[cryptpad-user1@my.awesome.website/YZgXQxKR0Rcb6r6CmxHPdAGLVludrAF2lEnkbx1vVOo=]",
+     *      "[cryptpad-user2@my.awesome.website/jA-9c5iNuG7SyxzGCjwJXVnk5NPfAOO8fQuQ0dC83RE=]",
+     *  ]
+     *
      */
-/*
     adminKeys: [
-        //"[cryptpad-user1@my.awesome.website/YZgXQxKR0Rcb6r6CmxHPdAGLVludrAF2lEnkbx1vVOo=]",
+
     ],
-*/
-
-    /*  CryptPad's administration panel includes a "support" tab
-     *  wherein administrators with a secret key can view messages
-     *  sent from users via the encrypted forms on the /support/ page
-     *
-     *  To enable this functionality:
-     *    run `node ./scripts/generate-admin-keys.js`
-     *    save the public key in your config in the value below
-     *    add the private key via the admin panel
-     *    and back it up in a secure manner
-     *
-     */
-    // supportMailboxPublicKey: "",
-
-    /*  We're very proud that CryptPad is available to the public as free software!
-     *  We do, however, still need to pay our bills as we develop the platform.
-     *
-     *  By default CryptPad will prompt users to consider donating to
-     *  our OpenCollective campaign. We publish the state of our finances periodically
-     *  so you can decide for yourself whether our expenses are reasonable.
-     *
-     *  You can disable any solicitations for donations by setting 'removeDonateButton' to true,
-     *  but we'd appreciate it if you didn't!
-     */
-    //removeDonateButton: false,
-
-    /*  CryptPad will display a point of contact for your instance on its contact page
-     *  (/contact.html) if you provide it below.
-     */
-    adminEmail: '{{ cryptpad_admin_email }}',
-
-    /*
-     *  By default, CryptPad contacts one of our servers once a day.
-     *  This check-in will also send some very basic information about your instance including its
-     *  version and the adminEmail so we can reach you if we are aware of a serious problem.
-     *  We will never sell it or send you marketing mail.
-     *
-     *  If you want to block this check-in and remain set 'blockDailyCheck' to true.
-     */
-    //blockDailyCheck: false,
-
-    /*
-     *  By default users get 50MB of storage by registering on an instance.
-     *  You can set this value to whatever you want.
-     *
-     *  hint: 50MB is 50 * 1024 * 1024
-     */
-    defaultStorageLimit: {{ cryptpad_default_storage_limit }} * 1024 * 1024,
-
 
     /* =====================
      *        STORAGE
@@ -170,7 +176,7 @@ module.exports = {
      *  This archived data still takes up space and so you'll probably still want to
      *  remove these files after a brief period.
      *
-     *  cryptpad/scripts/evict-inactive.js is intended to be run daily
+     *  cryptpad/scripts/evict-archived.js is intended to be run daily
      *  from a crontab or similar scheduling service.
      *
      *  The intent with this feature is to provide a safety net in case of accidental
@@ -206,29 +212,6 @@ module.exports = {
      *  defaults to 20MB if no value is provided
      */
     maxUploadSize: {{ cryptpad_maximum_upload_size }} * 1024 * 1024,
-
-    /*
-     *  CryptPad allows administrators to give custom limits to their friends.
-     *  add an entry for each friend, identified by their user id,
-     *  which can be found on the settings page. Include a 'limit' (number of bytes),
-     *  a 'plan' (string), and a 'note' (string).
-     *
-     *  hint: 1GB is 1024 * 1024 * 1024 bytes
-     */
-/*
-    customLimits: {
-        "[cryptpad-user1@my.awesome.website/YZgXQxKR0Rcb6r6CmxHPdAGLVludrAF2lEnkbx1vVOo=]": {
-            limit: 20 * 1024 * 1024 * 1024,
-            plan: 'insider',
-            note: 'storage space donated by my.awesome.website'
-        },
-        "[cryptpad-user2@my.awesome.website/GdflkgdlkjeworijfkldfsdflkjeEAsdlEnkbx1vVOo=]": {
-            limit: 10 * 1024 * 1024 * 1024,
-            plan: 'insider',
-            note: 'storage space donated by my.awesome.website'
-        }
-    },
-*/
 
     /*  Users with premium accounts (those with a plan included in their customLimit)
      *  can benefit from an increased upload size limit. By default they are restricted to the same
@@ -284,6 +267,8 @@ module.exports = {
      */
     blobStagingPath: './data/blobstage',
 
+    decreePath: './data/decrees',
+
     /* CryptPad supports logging events directly to the disk in a 'logs' directory
      * Set its location here, or set it to false (or nothing) if you'd rather not log
      */
@@ -327,4 +312,13 @@ module.exports = {
      *  (false by default)
      */
     verbose: false,
+
+    /*  Surplus information:
+     *
+     *  'installMethod' is included in server telemetry to voluntarily
+     *  indicate how many instances are using unofficial installation methods
+     *  such as Docker.
+     *
+     */
+    installMethod: 'unspecified',
 };


### PR DESCRIPTION
This commit removes variables which had been either added to https://github.com/cryptpad/cryptpad/commits/2024.12.0/config/config.example.js or removed / obsoleted from the file by the upstream project.

See:
- https://github.com/cryptpad/cryptpad/commit/176f4853a9cdceb437def3e71a6a8dcbc8233e98
- https://github.com/cryptpad/cryptpad/commit/ae2e7818035455994069dda41aaf4af6a2eecada
- https://github.com/cryptpad/cryptpad/commit/1f86578920d7f9ff849e473ec78e564d24e7f29a
- https://github.com/cryptpad/cryptpad/commit/230d0ce55e8fbbc53f5624b296cbcc856afaa1f9
- https://github.com/cryptpad/cryptpad/commit/a2b98623f1f40cfa2afb4cb4b604826518776e5f
- https://github.com/cryptpad/cryptpad/commit/30d956b52fc02f9e55c3ceebf281372d26d59d49
- https://github.com/cryptpad/cryptpad/commit/1879fd2226d210407fbd4ed81a111376407fa78b
- https://github.com/cryptpad/cryptpad/commit/38694fd463f1a12b3a1e585576a64fb7579fd68f
- https://github.com/cryptpad/cryptpad/commit/9a5de41ae5275b13803ecba2eb57615992c088f8