### PR TITLE
Update settings files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,9 @@ cryptpad_gid: ''
 cryptpad_version: 2024.12.0
 
 # CryptPad main domain FQDN
-cryptpad_main_domain: ''
+cryptpad_main_hostname: ''
 # CryptPad sandbox subdomain FQDN
-cryptpad_sandbox_domain: ''
+cryptpad_sandbox_hostname: ''
 
 
 cryptpad_base_path: "/{{ cryptpad_identifier }}"
@@ -83,7 +83,7 @@ cryptpad_container_labels_traefik_docker_network: "{{ cryptpad_container_network
 # MAIN #
 ########
 
-cryptpad_main_container_labels_traefik_hostname: "{{ cryptpad_main_domain }}"
+cryptpad_main_container_labels_traefik_hostname: "{{ cryptpad_main_hostname }}"
 cryptpad_main_container_labels_traefik_rule: "Host(`{{ cryptpad_main_container_labels_traefik_hostname }}`)"
 cryptpad_main_container_labels_traefik_priority: 0
 cryptpad_main_container_labels_traefik_entrypoints: web-secure
@@ -158,7 +158,7 @@ cryptpad_main_hsts_preload_enabled: false
 # SANDBOX #
 ###########
 
-cryptpad_sandbox_container_labels_traefik_hostname: "{{ cryptpad_sandbox_domain }}"
+cryptpad_sandbox_container_labels_traefik_hostname: "{{ cryptpad_sandbox_hostname }}"
 cryptpad_sandbox_container_labels_traefik_rule: "Host(`{{ cryptpad_sandbox_container_labels_traefik_hostname }}`)"
 cryptpad_sandbox_container_labels_traefik_priority: 0
 cryptpad_sandbox_container_labels_traefik_entrypoints: web-secure
@@ -208,7 +208,7 @@ cryptpad_sandbox_http_header_content_type_options: nosniff
 
 # Specifies the value of the `Content-Security-Policy` header.
 # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-cryptpad_sandbox_http_header_content_security_policy: "frame-ancestors 'self' https://{{ cryptpad_main_domain }}"
+cryptpad_sandbox_http_header_content_security_policy: "frame-ancestors 'self' https://{{ cryptpad_main_hostname }}"
 
 # Specifies the value of the `Permission-Policy` header.
 # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permission-Policy

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,6 @@
   with_items:
     - config.js
 
-
 - name: Ensure CryptPad image is pulled
   community.docker.docker_image:
     name: "{{ cryptpad_container_image }}"

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -13,9 +13,8 @@
     - cryptpad_identifier
     - cryptpad_uid
     - cryptpad_gid
-    - cryptpad_main_domain
-    - cryptpad_sandbox_domain
-    - cryptpad_admin_email
+    - cryptpad_main_hostname
+    - cryptpad_sandbox_hostname
 
 - when: cryptpad_container_labels_traefik_enabled | bool
   block:
@@ -25,5 +24,5 @@
           You need to define a required configuration setting (`{{ item }}`).
       when: "vars[item] == ''"
       with_items:
-        - cryptpad_main_domain
-        - cryptpad_sandbox_domain
+        - cryptpad_main_hostname
+        - cryptpad_sandbox_hostname

--- a/templates/config.js.j2
+++ b/templates/config.js.j2
@@ -33,7 +33,7 @@ module.exports = {
  *  cryptpad/docs/example.nginx.conf (see the $main_domain variable)
  *
  */
-    httpUnsafeOrigin: 'https://{{ cryptpad_main_domain }}',
+    httpUnsafeOrigin: 'https://{{ cryptpad_main_hostname }}',
 
 /*  httpSafeOrigin is the URL that is used for the 'sandbox' described above.
  *  If you're testing or developing with CryptPad on your local machine then
@@ -54,7 +54,7 @@ module.exports = {
  *
  *  CUSTOMIZE AND UNCOMMENT THIS FOR PRODUCTION INSTALLATIONS.
  */
-    httpSafeOrigin: "https://{{ cryptpad_sandbox_domain }}",
+    httpSafeOrigin: "https://{{ cryptpad_sandbox_hostname }}",
 
 /*  httpAddress specifies the address on which the nodejs server
  *  should be accessible. By default it will listen on localhost

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -4,8 +4,9 @@ SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
-CPAD_MAIN_DOMAIN={{ cryptpad_main_domain }}
-CPAD_SANDBOX_DOMAIN={{ cryptpad_sandbox_domain }}
+CPAD_MAIN_DOMAIN={{ cryptpad_main_hostname }}
+CPAD_SANDBOX_DOMAIN={{ cryptpad_sandbox_hostname }}
 CPAD_HTTP2_DISABLE=true
+CPAD_CONF={{ cryptpad_config_path }}/config.js
 
 {{ cryptpad_environment_variables_additional_variables }}

--- a/templates/systemd/cryptpad.service.j2
+++ b/templates/systemd/cryptpad.service.j2
@@ -16,7 +16,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} kill {{ cryptpad_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ cryptpad_identifier }} 2>/dev/null || true'
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ cryptpad_identifier }} 2>/dev/null || true'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
@@ -37,6 +37,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ cryptpad_files_path }},dst=/cryptpad/datastore \
 			--mount type=bind,src={{ cryptpad_config_path }}/config.js,dst=/cryptpad/config/config.js,readonly \
 			--tmpfs=/.npm:rw,noexec,nosuid,size=100m \
+			--tmpfs=/tmp:rw,noexec,nosuid,size=100m \
 			{% for arg in cryptpad_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
@@ -49,7 +50,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network conne
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ cryptpad_identifier }}
 
-ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} kill {{ cryptpad_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ cryptpad_identifier }} 2>/dev/null || true'
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ cryptpad_identifier }} 2>/dev/null || true'
 
 Restart=always


### PR DESCRIPTION
These changes are enough to start the instance, but it is not enough to establish connection between the sandbox domain and the main domain at `https://cryptpad.example.com/drive/`, as loading it returns 502 error at loading `https://sandbox.progressiv.dev/drive/inner.html`. It might be related to CSP settings (https://github.com/cryptpad/cryptpad/blob/2024.12.0/lib/defaults.js) but I am not sure how to fix the error. Helps are appreciated!